### PR TITLE
Patch AudioSource.Play and AudioSource.Play(double)

### DIFF
--- a/Subtitles/Patches/AudioSourcePatch.cs
+++ b/Subtitles/Patches/AudioSourcePatch.cs
@@ -41,6 +41,28 @@ public class AudioSourcePatch
         }
     }
 
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(AudioSource.Play), new[] { typeof(double) })]
+    public static void PlayDelayed_Prefix(AudioSource __instance)
+    {
+        if (__instance.clip == null) return;
+        if (IsInWithinAudiableDisable(__instance, __instance.volume))
+        {
+            AddSubtitle(__instance.clip);
+        }
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(AudioSource.Play), new System.Type[] { })]
+    public static void Play_Prefix(AudioSource __instance)
+    {
+        if (__instance.clip == null) return;
+        if (IsInWithinAudiableDisable(__instance, __instance.volume))
+        {
+            AddSubtitle(__instance.clip);
+        }
+    }
+
     private static void AddSubtitle(AudioClip clip)
     {
         if (clip?.name is null ||


### PR DESCRIPTION
The majority of sounds in this game use AudioSource.PlayOneShot(), but there's a few that use AudioSource.Play(), sometimes from within an animation

One notable example I can think of is `MineBeep`, which isn't properly registered at the moment because it uses AudioSource.Play

This patch adds prefixes to both AudioSource.Play methods. I'm not sure if .Play(double) is used anywhere in the game, but I figured I might as well throw it in (just in case)